### PR TITLE
Fixes issue preventing AJAX requests from loading from Internet Explorer #20

### DIFF
--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -52,7 +52,7 @@ module Huboard
 
     def self.registered(app)
       app.helpers Huboard::Common::Helpers
-      app.enable :sessions
+      app.use Rack::Session::Cookie, :key => 'rack.session', :path => '/'
       app.set :views, settings.root + "/views"
     end
 


### PR DESCRIPTION
There seemed to be an issue with cookie paths that was causing AJAX requests from Internet Explorer to try to authenticate again. The ensuing 302 redirect to Github caused the request to abort. This fix adjusts the cookie path and allows the `:user/:repo/board` page to properly render.
