### PR TITLE
Remove team membership code

### DIFF
--- a/.settings.sample
+++ b/.settings.sample
@@ -1,5 +1,4 @@
 set :secret_key, 'iam a secret key'
-set :team_id, "1235125"
 set :github_options, {
                             :secret    => '12351463161',
                             :client_id => '213414514636134631731364',

--- a/lib/api.rb
+++ b/lib/api.rb
@@ -14,16 +14,13 @@ module Huboard
 
     if ENV['GITHUB_CLIENT_ID']
       set :secret_key, ENV['SECRET_KEY']
-      set :team_id, ENV["TEAM_ID"]
-      set :user_name, ENV["USER_NAME"]
-      set :password, ENV["PASSWORD"]
       set :github_options, {
         :secret    => ENV['GITHUB_SECRET'],
         :client_id => ENV['GITHUB_CLIENT_ID'],
-        :scopes => "user,repo"
       }
       set :session_secret, ENV["SESSION_SECRET"]
     end
+   settings.github_options[:scopes] = "user,repo"
 
     before do
       authenticate! unless authenticated?

--- a/lib/app.rb
+++ b/lib/app.rb
@@ -20,16 +20,13 @@ module Huboard
 
     if ENV['GITHUB_CLIENT_ID']
       set :secret_key, ENV['SECRET_KEY']
-      set :team_id, ENV["TEAM_ID"]
-      set :user_name, ENV["USER_NAME"]
-      set :password, ENV["PASSWORD"]
       set :github_options, {
         :secret    => ENV['GITHUB_SECRET'],
         :client_id => ENV['GITHUB_CLIENT_ID'],
-        :scopes => "user,repo"
       }
       set :session_secret, ENV["SESSION_SECRET"]
     end
+    settings.github_options[:scopes] = "user,repo"
 
     PUBLIC_URLS = ['/', '/logout']
     before do
@@ -40,11 +37,7 @@ module Huboard
       def protected! 
         return current_user if authenticated?
         authenticate! 
-        #HAX! TODO remove
-        ghee = Ghee.new({ :basic_auth => {:user_name => settings.user_name, :password => settings.password}})
-        Stint::Github.new(ghee).add_to_team(settings.team_id, current_user.login) unless github_team_access? settings.team_id
         current_user
-        github_team_authenticate! team_id
       end
     end
 

--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -46,9 +46,6 @@ module Huboard
         @base_url ||= "#{request.env['rack.url_scheme']}://#{request.env['HTTP_HOST']}"
       end
 
-      def team_id
-        settings.team_id
-      end
     end
 
     def self.registered(app)


### PR DESCRIPTION
_This pull request is a bit presumptuous because I don't know what the team membership was used for, but it was labeled with "#HAX! TODO remove" so I went ahead and removed it.  It didn't seem to be used for anything._

Don't add authenticated users to a team.

Also always set OAuth scope to user,repo.
