### PR TITLE
Custom column background colors

### DIFF
--- a/public/scripts/modules/board/views/columnView.js
+++ b/public/scripts/modules/board/views/columnView.js
@@ -28,6 +28,19 @@ define(["text!../templates/column.html","./cardView"],function(template, CardVie
          out: $.proxy(this.onOut, this)
       });
 
+      var result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(this.column.color);
+      var rgb = result ? {
+        r: parseInt(result[1], 16),
+        g: parseInt(result[2], 16),
+        b: parseInt(result[3], 16)
+      } : null;
+
+      var rgbacolor    = "rgba(" + rgb.r + "," + rgb.g + "," + rgb.b + ",0.05)";
+      $("ul",this.el)
+      .css({
+        "background-color": rgbacolor,
+      });
+
       return this;
     },
     onReceive: function(ev, ui){

--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -183,7 +183,7 @@ table td {
  table li.drop-shadow {
    list-style: none;
    padding: 30px 5px 10px 5px;
-   margin: 10px 0;
+   margin: 0 0 10px 0;
    cursor:move;
    position:relative;
  }
@@ -230,6 +230,9 @@ table li a.close:hover {
  table li a small {
    color: #999;
    padding-right:2px;
+ }
+ table .ui-sortable {
+   padding: 10px 0 0 0;
  }
  table .ui-sortable-placeholder {
    background:#ccc;


### PR DESCRIPTION
I've been playing around with the idea presented in issue #49 to distinguish columns.

I'm submitting this as a pull request to further that discussion. @rauhryan, I duplicated your hex/rgb code and added a column background based on the status label. The code's working fine, but I'm not finding it that appealing visually. Don't know if you'd want to push this on people, as is.

Maybe it could be toned down even more on the alpha. A lot depends on the label colors selected by the user, and there's no on/off preference, except for using very light colors.

A combination of persistent headers and mo' alpha chop might be the way to go?
