### PR TITLE
Use huboard gemset instead of heroku

### DIFF
--- a/.rvmrc.sample
+++ b/.rvmrc.sample
@@ -1,1 +1,1 @@
-rvm 1.9.2@heroku
+rvm 1.9.2@huboard


### PR DESCRIPTION
Very very basic PR: I changed the default gemset in the rvmrc as `heroku` can be conflicting with what people already have on their machines. 

Anyways, thanks for the project, it's incredibly useful!
