### PR TITLE
Show entire title of issues (like Trello)

### DIFF
--- a/public/css/scss/_board.scss
+++ b/public/css/scss/_board.scss
@@ -180,9 +180,7 @@
   }
   .title {
     padding-right: 30px;
-    overflow:hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis;
+    word-wrap: break-word;
   }         
   .milestone {
     color: $lightGrey;


### PR DESCRIPTION
When you get to around 7 columns, you can no longer have very long issue titles because you can only see 1 or 2 words. This fixes that so that now you get something like this.

![Issues](http://screencloud.net/img/screenshots/bbd07b34a08b240471812cd0b6bd4592.png)

The entire board still looks great, I just can't screenshot it since it's private :smile: 

<!---
@huboard:{"order":26.0}
-->
