### PR TITLE
tiny documentation fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,13 @@
 
 Add labels to your repository with the following pattern
 
->  # - Title
+>  # - Title  
 
->  # == index of column
->  Title == column header
+Where:
+
+>  '#' == index of column
+
+> 'Title' == column header
 
 Example:
 


### PR DESCRIPTION
Fixing the README. The syntax was making it hard to understand how to create labels.  The explanation of '#' and 'Title' was all one one line.
