### PR TITLE
proper label indexes in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ Where:
 
 Example:
 
->  1 - Backlog
+>  0 - Backlog
 
->  2 - Ready
+>  1 - Ready
 
->  3 - Working
+>  2 - Working
 
->  4 - Done
+>  3 - Done
 
 The number represents the index of the column and the will be the column header
 


### PR DESCRIPTION
If you don't label the first with a "0 - Backlog" instead of "1 - Backlog", your backlog issues will not show up under the Backlog column when you click on "Tasks".
