### PR TITLE
Add package.json so that readme does not need to specify what packages are requried

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ log/
 #*.min.css
 app.build.js
 .powenv
+node_modules

--- a/README.md
+++ b/README.md
@@ -177,9 +177,9 @@ Customize your values and run the following from your project root:
 Note: I know this is crap, trust me I will fix it.
 
 Before deploying there are a few step you need to do manually to prepare the assets for production.
-Will will need node.js installed as well as the requirejs, uglify-js (v1.x) and lazy npm packages.
+Will will need node.js installed and to run `npm` to install build dependencies.
 
-    npm install requirejs uglify-js@1 lazy
+    npm install
 
 Predeployment (if you've changed any js or css files) run the following rake tasks in this exact order
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "huboard_deploy_tools",
+  "description": "",
+  "private": true,
+  "author": "",
+  "version": "0.0.1",
+  "scripts": {},
+  "dependencies": {},
+  "devDependencies": {
+    "uglify-js": "~1.3.5",
+    "requirejs": "~2.1.6",
+    "lazy": "~1.0.11"
+  },
+  "engine": "node >= 0.10.4"
+}


### PR DESCRIPTION
A quick change that should help tie down the dependencies for the nodejs build steps.
