### PR TITLE
Collapse horizontal columns when width < 960

### DIFF
--- a/assets/stylesheets/flex_layout.css.scss
+++ b/assets/stylesheets/flex_layout.css.scss
@@ -223,7 +223,7 @@
       @include flex(0 1 auto);
   }
  }
- @media only screen and (max-width: 1024px) {
+ @media only screen and (max-width: 959px) {
   .board {
     @include flex-direction(column);
     .column {


### PR DESCRIPTION
Change the fluid column collapse threshold from 1024 to 959 to make
dorks like me who use a narrow browser window happier while still
providing a reasonable view for users with truly narrow display
viewports.

Issue: #280
