### PR TITLE
Use a more accurate placeholder

### DIFF
--- a/assets/javascripts/board/templates/components/hb-markdown-editor.hbs
+++ b/assets/javascripts/board/templates/components/hb-markdown-editor.hbs
@@ -1,7 +1,7 @@
 {{#hb-tabs}}
   {{#hb-pane title="Compose"}}
     <div class="markdown-composer">
-      {{textarea autoresize=true value=markdown placeholder="Leave a comment"}}
+      {{textarea autoresize=true value=markdown placeholder="Description"}}
     </div>
   {{/hb-pane}}
   {{#hb-pane title="Preview"}}


### PR DESCRIPTION
The placeholder for the issue composer is misleading. The field labeled "Leave a comment" is actually a field for the issue description.
